### PR TITLE
add bootstrap to keep event list fields in a column format

### DIFF
--- a/src/client/app/FriendEventList.jsx
+++ b/src/client/app/FriendEventList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import FriendEventListItem from './FriendEventListItem.jsx'
 
 const FriendEventList = (props) => (
-  <div className='eventlist'>
+  <div className="eventlist container-fluid">
     {props.friendEventsArr.map((event, i) => <FriendEventListItem accessToken={props.accessToken} key={i} event={event}/>)}  
   </div>
 )

--- a/src/client/app/FriendEventListItem.jsx
+++ b/src/client/app/FriendEventListItem.jsx
@@ -33,11 +33,11 @@ class FriendEventListItem extends React.Component {
 
     return (
       <div>
-      <div className="panel list-item" onClick={this.handleClickListItem}>
-        <span className="glyphicon glyphicon-globe col-md-1"></span>
-        <span className={`${accepted} ${rejected} col-md-4`}>{this.props.event.title}</span>
-        <span className={`${accepted} ${rejected} col-md-4`}>{date.format('dddd D') + 'th'} at {this.props.event.time}</span>
-        <span className={`${accepted} ${rejected} col-md-3`}>{this.props.event.attendees.length}<span> people IN</span></span>
+      <div className="panel list-item row" onClick={this.handleClickListItem}>
+        <div className="glyphicon glyphicon-globe col-sm-1"></div>
+        <div className={`${accepted} ${rejected} col-sm-4`}>{this.props.event.title}</div>
+        <div className={`${accepted} ${rejected} col-sm-4`}>{date.format('dddd D') + 'th'} at {this.props.event.time}</div>
+        <div className={`${accepted} ${rejected} col-sm-3`}>{this.props.event.attendees.length}<span> people IN</span></div>
         <br/>
       </div>
         {this.state.clicked ? <FriendDetailedView

--- a/src/client/app/OwnerEventList.jsx
+++ b/src/client/app/OwnerEventList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import OwnerEventListItem from './OwnerEventListItem.jsx'
 
 const OwnerEventList = (props) => (
-  <div className='eventlist'>
+  <div className='eventlist container-fluid'>
     {props.ownerEventsArr.map((event, i) => <OwnerEventListItem key={i}event={event}/>)}  
   </div>
 )

--- a/src/client/app/OwnerEventListItem.jsx
+++ b/src/client/app/OwnerEventListItem.jsx
@@ -21,11 +21,11 @@ class OwnerEventListItem extends React.Component {
 
     return (
       <div>
-      <div className="panel list-item" onClick={this.handleClickListItem}>
-        <span className="glyphicon glyphicon-globe col-md-1"></span>
-        <span className="col-md-4">{this.props.event.title}</span>
-        <span className="col-md-4">{date.format('dddd D') + 'th'} at {this.props.event.time}</span>
-        <span className="col-md-3">{this.props.event.attendees.length}<span> people IN</span></span>
+      <div className="panel list-item row" onClick={this.handleClickListItem}>  
+        <div className="glyphicon glyphicon-globe col-sm-1"></div>
+        <div className="col-sm-4">{this.props.event.title}</div>
+        <div className="col-sm-4">{date.format('dddd D') + 'th'} at {this.props.event.time}</div>
+        <div className="col-sm-3">{this.props.event.attendees.length}<span> people IN</span></div>
         <br/>
       </div>
         {this.state.clicked ? <OwnerDetailedView event={this.props.event}/> : '' }


### PR DESCRIPTION
This keeps the various fields in the event lists in a column format for displays of bootstrap size sm and larger.